### PR TITLE
Set aria-hidden="true" for accessibility

### DIFF
--- a/lib/lucide-rails.rb
+++ b/lib/lucide-rails.rb
@@ -11,6 +11,7 @@ end
 module LucideRails
   # Extracted from options contained in svg tags from original/*.svg
   DEFAULT_OPTIONS = {
+    "aria-hidden" => "true",
     "width" => "24",
     "height" => "24",
     "viewBox" => "0 0 24 24",


### PR DESCRIPTION
Hi, thanks for the gem!

For accessibility reasons, it is not necessary for screen readers to read the icons. Setting aria-hidden="true" by default is a good approach to ensure this.