### PR TITLE
Fix: use `ActiveSupport.on_load` in railtie to avoid premature ActionView load

### DIFF
--- a/lib/lucide-rails/railtie.rb
+++ b/lib/lucide-rails/railtie.rb
@@ -3,7 +3,9 @@
 module LucideRails
   class Railtie < Rails::Railtie
     initializer "lucide-rails.helper" do
-      ActionView::Base.include LucideRails::RailsHelper
+      ActiveSupport.on_load(:action_view) do
+        include LucideRails::RailsHelper
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

The railtie's initializer references `ActionView::Base` directly, which on Rails main triggers a warning on every boot:

> :action_view was loaded before application initialization.
> Prematurely executing load hooks will slow down your boot time
> and could cause conflicts with the load order of your application.
> Please wrap your code with an on_load hook:
> 
>   ActiveSupport.on_load(:action_view) do
>     # your code here
>   end

## Fix

Use `ActiveSupport.on_load(:action_view)` to defer the include until ActionView is actually loaded.